### PR TITLE
MAD-2075 Gradient and dashed line

### DIFF
--- a/MPChartExample/src/main/AndroidManifest.xml
+++ b/MPChartExample/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".mysugr.MySugrActivity" />
         <activity android:name="LineChartActivity1" />
         <activity android:name="LineChartActivity2" />
         <activity android:name="LineChartTime" />

--- a/MPChartExample/src/main/AndroidManifest.xml
+++ b/MPChartExample/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
             </intent-filter>
         </activity>
         <activity android:name=".mysugr.MySugrActivity" />
+        <activity android:name=".mysugr.MySugrLineChartActivity" />
         <activity android:name="LineChartActivity1" />
         <activity android:name="LineChartActivity2" />
         <activity android:name="LineChartTime" />

--- a/MPChartExample/src/main/java/com/xxmassdeveloper/mpchartexample/mysugr/MySugrActivity.java
+++ b/MPChartExample/src/main/java/com/xxmassdeveloper/mpchartexample/mysugr/MySugrActivity.java
@@ -1,0 +1,67 @@
+
+package com.xxmassdeveloper.mpchartexample.mysugr;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.View;
+import android.view.WindowManager;
+import android.widget.AdapterView;
+import android.widget.AdapterView.OnItemClickListener;
+import android.widget.ListView;
+
+import com.github.mikephil.charting.utils.Utils;
+import com.xxmassdeveloper.mpchartexample.LineChartActivity1;
+import com.xxmassdeveloper.mpchartexample.R;
+import com.xxmassdeveloper.mpchartexample.notimportant.ContentItem;
+import com.xxmassdeveloper.mpchartexample.notimportant.MyAdapter;
+
+import java.util.ArrayList;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+public class MySugrActivity
+		extends AppCompatActivity
+		implements OnItemClickListener {
+	
+	@Override
+	protected void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
+				WindowManager.LayoutParams.FLAG_FULLSCREEN);
+		setContentView(R.layout.activity_main);
+		
+		setTitle("MySugr examples");
+		
+		// initialize the utilities
+		Utils.init(this);
+		
+		ArrayList<ContentItem> objects = new ArrayList<>();
+		
+		objects.add(0, new ContentItem("Line Charts"));
+		objects.add(1, new ContentItem("Basic", "Test."));
+		
+		MyAdapter adapter = new MyAdapter(this, objects);
+		
+		ListView lv = findViewById(R.id.listView1);
+		lv.setAdapter(adapter);
+		
+		lv.setOnItemClickListener(this);
+	}
+	
+	@Override
+	public void onItemClick(AdapterView<?> av, View v, int pos, long arg3) {
+		
+		Intent i = null;
+		
+		switch (pos) {
+			case 1:
+				i = new Intent(this, LineChartActivity1.class);
+				break;
+		}
+		
+		if (i != null) startActivity(i);
+		
+		overridePendingTransition(R.anim.move_right_in_activity, R.anim.move_left_out_activity);
+	}
+	
+}

--- a/MPChartExample/src/main/java/com/xxmassdeveloper/mpchartexample/mysugr/MySugrActivity.java
+++ b/MPChartExample/src/main/java/com/xxmassdeveloper/mpchartexample/mysugr/MySugrActivity.java
@@ -55,7 +55,7 @@ public class MySugrActivity
 		
 		switch (pos) {
 			case 1:
-				i = new Intent(this, LineChartActivity1.class);
+				i = new Intent(this, MySugrLineChartActivity.class);
 				break;
 		}
 		

--- a/MPChartExample/src/main/java/com/xxmassdeveloper/mpchartexample/mysugr/MySugrLineChartActivity.java
+++ b/MPChartExample/src/main/java/com/xxmassdeveloper/mpchartexample/mysugr/MySugrLineChartActivity.java
@@ -1,35 +1,17 @@
 
 package com.xxmassdeveloper.mpchartexample.mysugr;
 
-import android.Manifest;
-import android.content.Intent;
-import android.content.pm.PackageManager;
 import android.graphics.Color;
-import android.graphics.DashPathEffect;
-import android.graphics.drawable.Drawable;
-import android.net.Uri;
+import android.graphics.Paint;
 import android.os.Bundle;
-import android.util.Log;
-import android.view.Menu;
-import android.view.MenuItem;
 import android.view.WindowManager;
-import android.widget.SeekBar;
-import android.widget.SeekBar.OnSeekBarChangeListener;
-import android.widget.TextView;
-
-import com.github.mikephil.charting.animation.Easing;
 import com.github.mikephil.charting.charts.LineChart;
 import com.github.mikephil.charting.components.XAxis;
 import com.github.mikephil.charting.components.YAxis;
 import com.github.mikephil.charting.data.Entry;
 import com.github.mikephil.charting.data.LineData;
 import com.github.mikephil.charting.data.LineDataSet;
-import com.github.mikephil.charting.formatter.IFillFormatter;
-import com.github.mikephil.charting.highlight.Highlight;
-import com.github.mikephil.charting.interfaces.dataprovider.LineDataProvider;
 import com.github.mikephil.charting.interfaces.datasets.ILineDataSet;
-import com.github.mikephil.charting.listener.OnChartValueSelectedListener;
-import com.github.mikephil.charting.utils.Utils;
 import com.xxmassdeveloper.mpchartexample.R;
 import com.xxmassdeveloper.mpchartexample.notimportant.DemoBase;
 
@@ -118,7 +100,7 @@ public class MySugrLineChartActivity extends DemoBase {
 		
 		List<Entry> gradientEntries = getDashedEntries();
 		LineDataSet gradientDataSet = createGradientDataSet(gradientEntries);
-		//dataSets.add(gradientDataSet);
+		dataSets.add(gradientDataSet);
 		
 		// create a data object with the data sets
 		LineData data = new LineData(dataSets);
@@ -131,8 +113,9 @@ public class MySugrLineChartActivity extends DemoBase {
 		LineDataSet dashedDataSet = new LineDataSet(entries, "dashed");
 		dashedDataSet.enableDashedLine(1f, 35f, 0f);
 		dashedDataSet.setColor(Color.GRAY);
-		dashedDataSet.setMode(LineDataSet.Mode.CUBIC_BEZIER);
+		dashedDataSet.setMode(LineDataSet.Mode.LINEAR);
 		dashedDataSet.setLineWidth(3f);
+		dashedDataSet.setStrokeCap(Paint.Cap.ROUND);
 		return dashedDataSet;
 	}
 	
@@ -143,7 +126,7 @@ public class MySugrLineChartActivity extends DemoBase {
 		int[] colors = new int[]{Color.RED, Color.YELLOW, Color.GREEN};
 		//gradientDataSet.setRangeColors(colors);
 		float[] rangeValues = new float[]{80, 60, 40, 20};
-		//gradientDataSet.setRangeValues(rangeValues);
+		// gradientDataSet.setRangeValues(rangeValues);
 		gradientDataSet.setColor(Color.GREEN);
 		gradientDataSet.setMode(LineDataSet.Mode.CUBIC_BEZIER);
 		gradientDataSet.setCubicIntensity(0.35f);

--- a/MPChartExample/src/main/java/com/xxmassdeveloper/mpchartexample/mysugr/MySugrLineChartActivity.java
+++ b/MPChartExample/src/main/java/com/xxmassdeveloper/mpchartexample/mysugr/MySugrLineChartActivity.java
@@ -1,0 +1,166 @@
+
+package com.xxmassdeveloper.mpchartexample.mysugr;
+
+import android.Manifest;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.graphics.Color;
+import android.graphics.DashPathEffect;
+import android.graphics.drawable.Drawable;
+import android.net.Uri;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.WindowManager;
+import android.widget.SeekBar;
+import android.widget.SeekBar.OnSeekBarChangeListener;
+import android.widget.TextView;
+
+import com.github.mikephil.charting.animation.Easing;
+import com.github.mikephil.charting.charts.LineChart;
+import com.github.mikephil.charting.components.XAxis;
+import com.github.mikephil.charting.components.YAxis;
+import com.github.mikephil.charting.data.Entry;
+import com.github.mikephil.charting.data.LineData;
+import com.github.mikephil.charting.data.LineDataSet;
+import com.github.mikephil.charting.formatter.IFillFormatter;
+import com.github.mikephil.charting.highlight.Highlight;
+import com.github.mikephil.charting.interfaces.dataprovider.LineDataProvider;
+import com.github.mikephil.charting.interfaces.datasets.ILineDataSet;
+import com.github.mikephil.charting.listener.OnChartValueSelectedListener;
+import com.github.mikephil.charting.utils.Utils;
+import com.xxmassdeveloper.mpchartexample.R;
+import com.xxmassdeveloper.mpchartexample.notimportant.DemoBase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import androidx.core.content.ContextCompat;
+
+/**
+ * Example of a heavily customized {@link LineChart} with limit lines, custom line shapes, etc.
+ *
+ * @version 3.1.0
+ * @since 1.7.4
+ */
+public class MySugrLineChartActivity extends DemoBase {
+	
+	private LineChart chart;
+	
+	@Override
+	protected void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
+				WindowManager.LayoutParams.FLAG_FULLSCREEN);
+		setContentView(R.layout.activity_linechart);
+		
+		setTitle("MySugr line charts");
+		
+		{   // // Chart Style // //
+			chart = findViewById(R.id.chart1);
+			
+			// background color
+			chart.setBackgroundColor(Color.WHITE);
+			
+			// disable description text
+			chart.getDescription().setEnabled(false);
+			
+			// enable touch gestures
+			chart.setTouchEnabled(true);
+			
+			chart.setDrawGridBackground(false);
+			
+			
+			// enable scaling and dragging
+			chart.setDragEnabled(true);
+			chart.setScaleEnabled(true);
+			// chart.setScaleXEnabled(true);
+			// chart.setScaleYEnabled(true);
+			
+		}
+		
+		
+		YAxis yAxis;
+		{   // // Y-Axis Style // //
+			yAxis = chart.getAxisLeft();
+			
+			// disable dual axis (only use LEFT axis)
+			chart.getAxisRight().setEnabled(false);
+			
+			// axis range
+			yAxis.setAxisMinimum(0f);
+			yAxis.setAxisMaximum(100f);
+		}
+		
+		XAxis xAxis = chart.getXAxis();
+		xAxis.setAxisMinimum(0f);
+		xAxis.setAxisMaximum(100f);
+		
+		// add data
+		setData(45, 180);
+		
+		// draw points over time
+		chart.animateX(1500);
+	}
+	
+	@Override
+	protected void saveToGallery() {
+	
+	}
+	
+	private void setData(int count, float range) {
+		
+		ArrayList<ILineDataSet> dataSets = new ArrayList<>();
+		List<Entry> entries = getDashedEntries();
+		LineDataSet dashedDataSet = createDashedDataSet(entries);
+		dataSets.add(dashedDataSet);
+		
+		List<Entry> gradientEntries = getDashedEntries();
+		LineDataSet gradientDataSet = createGradientDataSet(gradientEntries);
+		dataSets.add(gradientDataSet);
+		
+		// create a data object with the data sets
+		LineData data = new LineData(dataSets);
+		
+		// set data
+		chart.setData(data);
+	}
+	
+	private LineDataSet createDashedDataSet(List<Entry> entries) {
+		LineDataSet dashedDataSet = new LineDataSet(entries, "dashed");
+		dashedDataSet.setColor(Color.GRAY);
+		dashedDataSet.setLineWidth(4f);
+		dashedDataSet.enableDashedLine(5f, 30f, 0f);
+		return dashedDataSet;
+	}
+	
+	private LineDataSet createGradientDataSet(List<Entry> entries) {
+		LineDataSet gradientDataSet = new LineDataSet(entries, "gradient");
+		gradientDataSet.setColor(Color.GRAY);
+		gradientDataSet.setLineWidth(4f);
+		int[] colors = new int[]{Color.RED, Color.YELLOW, Color.GREEN};
+		gradientDataSet.setRangeColors(colors);
+		float[] rangeValues = new float[]{80, 60, 40, 20};
+		gradientDataSet.setRangeValues(rangeValues);
+		gradientDataSet.setMode(LineDataSet.Mode.CUBIC_BEZIER);
+		gradientDataSet.setCubicIntensity(0.35f);
+		return gradientDataSet;
+	}
+	
+	private List<Entry> getDashedEntries() {
+		float multiplier = 10f;
+		List<Entry> entries = new ArrayList();
+		for (int index = 1; index < 10; index++) {
+			double y = Math.random() * 100;
+			Entry entry = new Entry(index * multiplier, (float) y);
+			entries.add(entry);
+		}
+		return entries;
+	}
+	
+	@Override
+	public void onPointerCaptureChanged(boolean hasCapture) {
+	
+	}
+}

--- a/MPChartExample/src/main/java/com/xxmassdeveloper/mpchartexample/mysugr/MySugrLineChartActivity.java
+++ b/MPChartExample/src/main/java/com/xxmassdeveloper/mpchartexample/mysugr/MySugrLineChartActivity.java
@@ -5,6 +5,7 @@ import android.graphics.Color;
 import android.graphics.Paint;
 import android.os.Bundle;
 import android.view.WindowManager;
+
 import com.github.mikephil.charting.charts.LineChart;
 import com.github.mikephil.charting.components.XAxis;
 import com.github.mikephil.charting.components.YAxis;
@@ -18,15 +19,14 @@ import com.xxmassdeveloper.mpchartexample.notimportant.DemoBase;
 import java.util.ArrayList;
 import java.util.List;
 
-import androidx.core.content.ContextCompat;
-
 /**
  * Example of a heavily customized {@link LineChart} with limit lines, custom line shapes, etc.
  *
  * @version 3.1.0
  * @since 1.7.4
  */
-public class MySugrLineChartActivity extends DemoBase {
+public class MySugrLineChartActivity
+		extends DemoBase {
 	
 	private LineChart chart;
 	
@@ -80,7 +80,7 @@ public class MySugrLineChartActivity extends DemoBase {
 		xAxis.setAxisMaximum(100f);
 		
 		// add data
-		setData(45, 180);
+		setData();
 		
 		// draw points over time
 		chart.animateX(1500);
@@ -91,8 +91,7 @@ public class MySugrLineChartActivity extends DemoBase {
 	
 	}
 	
-	private void setData(int count, float range) {
-		
+	private void setData() {
 		ArrayList<ILineDataSet> dataSets = new ArrayList<>();
 		List<Entry> entries = getDashedEntries();
 		LineDataSet dashedDataSet = createDashedDataSet(entries);
@@ -102,10 +101,7 @@ public class MySugrLineChartActivity extends DemoBase {
 		LineDataSet gradientDataSet = createGradientDataSet(gradientEntries);
 		dataSets.add(gradientDataSet);
 		
-		// create a data object with the data sets
 		LineData data = new LineData(dataSets);
-		
-		// set data
 		chart.setData(data);
 	}
 	
@@ -124,9 +120,9 @@ public class MySugrLineChartActivity extends DemoBase {
 		gradientDataSet.setColor(Color.GRAY);
 		gradientDataSet.setLineWidth(4f);
 		int[] colors = new int[]{Color.RED, Color.YELLOW, Color.GREEN};
-		//gradientDataSet.setRangeColors(colors);
+		gradientDataSet.setRangeColors(colors);
 		float[] rangeValues = new float[]{80, 60, 40, 20};
-		// gradientDataSet.setRangeValues(rangeValues);
+		gradientDataSet.setRangeValues(rangeValues);
 		gradientDataSet.setColor(Color.GREEN);
 		gradientDataSet.setMode(LineDataSet.Mode.CUBIC_BEZIER);
 		gradientDataSet.setCubicIntensity(0.35f);

--- a/MPChartExample/src/main/java/com/xxmassdeveloper/mpchartexample/mysugr/MySugrLineChartActivity.java
+++ b/MPChartExample/src/main/java/com/xxmassdeveloper/mpchartexample/mysugr/MySugrLineChartActivity.java
@@ -118,7 +118,7 @@ public class MySugrLineChartActivity extends DemoBase {
 		
 		List<Entry> gradientEntries = getDashedEntries();
 		LineDataSet gradientDataSet = createGradientDataSet(gradientEntries);
-		dataSets.add(gradientDataSet);
+		//dataSets.add(gradientDataSet);
 		
 		// create a data object with the data sets
 		LineData data = new LineData(dataSets);
@@ -129,9 +129,10 @@ public class MySugrLineChartActivity extends DemoBase {
 	
 	private LineDataSet createDashedDataSet(List<Entry> entries) {
 		LineDataSet dashedDataSet = new LineDataSet(entries, "dashed");
+		dashedDataSet.enableDashedLine(1f, 35f, 0f);
 		dashedDataSet.setColor(Color.GRAY);
-		dashedDataSet.setLineWidth(4f);
-		dashedDataSet.enableDashedLine(5f, 30f, 0f);
+		dashedDataSet.setMode(LineDataSet.Mode.CUBIC_BEZIER);
+		dashedDataSet.setLineWidth(3f);
 		return dashedDataSet;
 	}
 	
@@ -140,9 +141,10 @@ public class MySugrLineChartActivity extends DemoBase {
 		gradientDataSet.setColor(Color.GRAY);
 		gradientDataSet.setLineWidth(4f);
 		int[] colors = new int[]{Color.RED, Color.YELLOW, Color.GREEN};
-		gradientDataSet.setRangeColors(colors);
+		//gradientDataSet.setRangeColors(colors);
 		float[] rangeValues = new float[]{80, 60, 40, 20};
-		gradientDataSet.setRangeValues(rangeValues);
+		//gradientDataSet.setRangeValues(rangeValues);
+		gradientDataSet.setColor(Color.GREEN);
 		gradientDataSet.setMode(LineDataSet.Mode.CUBIC_BEZIER);
 		gradientDataSet.setCubicIntensity(0.35f);
 		return gradientDataSet;

--- a/MPChartExample/src/main/java/com/xxmassdeveloper/mpchartexample/notimportant/ContentItem.java
+++ b/MPChartExample/src/main/java/com/xxmassdeveloper/mpchartexample/notimportant/ContentItem.java
@@ -3,19 +3,19 @@ package com.xxmassdeveloper.mpchartexample.notimportant;
 /**
  * Created by Philipp Jahoda on 07/12/15.
  */
-class ContentItem {
+public class ContentItem {
 
     final String name;
     final String desc;
     boolean isSection = false;
 
-    ContentItem(String n) {
+    public ContentItem(String n) {
         name = n;
         desc = "";
         isSection = true;
     }
 
-    ContentItem(String n, String d) {
+    public ContentItem(String n, String d) {
         name = n;
         desc = d;
     }

--- a/MPChartExample/src/main/java/com/xxmassdeveloper/mpchartexample/notimportant/MainActivity.java
+++ b/MPChartExample/src/main/java/com/xxmassdeveloper/mpchartexample/notimportant/MainActivity.java
@@ -45,6 +45,7 @@ import com.xxmassdeveloper.mpchartexample.ScrollViewActivity;
 import com.xxmassdeveloper.mpchartexample.StackedBarActivity;
 import com.xxmassdeveloper.mpchartexample.StackedBarActivityNegative;
 import com.xxmassdeveloper.mpchartexample.fragments.SimpleChartDemo;
+import com.xxmassdeveloper.mpchartexample.mysugr.MySugrActivity;
 
 import java.util.ArrayList;
 
@@ -67,7 +68,7 @@ public class MainActivity extends AppCompatActivity implements OnItemClickListen
         ArrayList<ContentItem> objects = new ArrayList<>();
 
         ////
-        objects.add(0, new ContentItem("Line Charts"));
+        objects.add(0, new ContentItem("MySugr charts", "Custom charts"));
 
         objects.add(1, new ContentItem("Basic", "Simple line chart."));
         objects.add(2, new ContentItem("Multiple", "Show multiple data sets."));
@@ -136,6 +137,9 @@ public class MainActivity extends AppCompatActivity implements OnItemClickListen
         Intent i = null;
 
         switch (pos) {
+            case 0:
+                i = new Intent(this, MySugrActivity.class);
+                break;
             case 1:
                 i = new Intent(this, LineChartActivity1.class);
                 break;

--- a/MPChartExample/src/main/java/com/xxmassdeveloper/mpchartexample/notimportant/MyAdapter.java
+++ b/MPChartExample/src/main/java/com/xxmassdeveloper/mpchartexample/notimportant/MyAdapter.java
@@ -18,12 +18,12 @@ import java.util.List;
 /**
  * Created by Philipp Jahoda on 07/12/15.
  */
-class MyAdapter extends ArrayAdapter<ContentItem> {
+public class MyAdapter extends ArrayAdapter<ContentItem> {
 
     private final Typeface mTypeFaceLight;
     private final Typeface mTypeFaceRegular;
 
-    MyAdapter(Context context, List<ContentItem> objects) {
+    public MyAdapter(Context context, List<ContentItem> objects) {
         super(context, 0, objects);
 
         mTypeFaceLight = Typeface.createFromAsset(context.getAssets(), "OpenSans-Light.ttf");

--- a/MPChartLib/build.gradle
+++ b/MPChartLib/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     ext.publishingInfo = [
-            version      : '3.1.0.mysugr.2',
+            version      : '3.1.0.mysugr.3',
             org          : 'mysugr',
             lib          : 'MPAndroidChart-mysugr',
             group        : 'com.github.PhilJay',

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/data/LineDataSet.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/data/LineDataSet.java
@@ -4,6 +4,7 @@ package com.github.mikephil.charting.data;
 import android.content.Context;
 import android.graphics.Color;
 import android.graphics.DashPathEffect;
+import android.graphics.Paint;
 import android.util.Log;
 
 import com.github.mikephil.charting.formatter.DefaultFillFormatter;
@@ -69,7 +70,8 @@ public class LineDataSet
     private int[] rangeColors = new int[1];
 
     private float[] rangeValues = new float[1];
-
+    
+    private Paint.Cap mStrokeCap = LineDataSet.DEFAULT_STROKE_CAP;
 
     public LineDataSet(List<Entry> yVals, String label) {
         super(yVals, label);
@@ -429,8 +431,18 @@ public class LineDataSet
     public float[] getRangeValues() {
         return rangeValues;
     }
-
-    public void setRangeValues(float[] rangeValues) {
+	
+	@Override
+	public Paint.Cap getStrokeCap() {
+		return mStrokeCap;
+	}
+	
+	@Override
+	public void setStrokeCap(Paint.Cap strokeCap) {
+    	mStrokeCap = strokeCap;
+	}
+	
+	public void setRangeValues(float[] rangeValues) {
         this.rangeValues = rangeValues;
     }
 
@@ -440,4 +452,6 @@ public class LineDataSet
         CUBIC_BEZIER,
         HORIZONTAL_BEZIER
     }
+    
+    public static Paint.Cap DEFAULT_STROKE_CAP = Paint.Cap.BUTT;
 }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/data/LineDataSet.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/data/LineDataSet.java
@@ -423,6 +423,7 @@ public class LineDataSet
         return rangeColors;
     }
 
+    @Override
     public void setRangeColors(int[] rangeColors) {
         this.rangeColors = rangeColors;
     }
@@ -430,6 +431,11 @@ public class LineDataSet
     @Override
     public float[] getRangeValues() {
         return rangeValues;
+    }
+    
+    @Override
+    public void setRangeValues(float[] rangeValues) {
+        this.rangeValues = rangeValues;
     }
 	
 	@Override
@@ -441,10 +447,6 @@ public class LineDataSet
 	public void setStrokeCap(Paint.Cap strokeCap) {
     	mStrokeCap = strokeCap;
 	}
-	
-	public void setRangeValues(float[] rangeValues) {
-        this.rangeValues = rangeValues;
-    }
 
     public enum Mode {
         LINEAR,

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/data/LineDataSet.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/data/LineDataSet.java
@@ -422,8 +422,15 @@ public class LineDataSet
     public int[] getRangeColors() {
         return rangeColors;
     }
-
-    @Override
+    
+    /**
+     * CAUTION: Experimental API, not everything might work as you expect it!
+     * Colors are set as gradient as according to our use case only.
+     *
+     * Always call {@link #setRangeValues} too!
+     *
+     * @param rangeColors 3 colors have to be set, which are used for the linear gradient.
+     */
     public void setRangeColors(int[] rangeColors) {
         this.rangeColors = rangeColors;
     }
@@ -433,7 +440,16 @@ public class LineDataSet
         return rangeValues;
     }
     
-    @Override
+    /**
+     * CAUTION: Experimental API, not everything might work as you expect it!
+     * Colors are set as gradient as according to our use case only.
+     * Calling this method on a dataset ignores its {@link #getColor()} and draws the gradient
+     * colors of {@link #getRangeColors()} instead.
+     *
+     * Always call {@link #setRangeColors} too!
+     *
+     * @param rangeValues 4 range values have to be set the correspond to ranges on the y axis
+     */
     public void setRangeValues(float[] rangeValues) {
         this.rangeValues = rangeValues;
     }
@@ -442,8 +458,10 @@ public class LineDataSet
 	public Paint.Cap getStrokeCap() {
 		return mStrokeCap;
 	}
-	
-	@Override
+    
+    /**
+     * @param strokeCap specifies how the start and end of lines are drawn
+     */
 	public void setStrokeCap(Paint.Cap strokeCap) {
     	mStrokeCap = strokeCap;
 	}

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/interfaces/datasets/ILineDataSet.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/interfaces/datasets/ILineDataSet.java
@@ -104,8 +104,30 @@ public interface ILineDataSet
     IFillFormatter getFillFormatter();
 
     int[] getRangeColors();
-
+    
+    /**
+	 * CAUTION: Experimental API, not everything might work as you expect it!
+     * Colors are set as gradient as according to our use case only.
+     *
+     * Always call {@link #setRangeValues} too!
+     *
+     * @param rangeColors 3 colors have to be set, which are used for the linear gradient.
+     */
+    void setRangeColors(int[] rangeColors);
+    
     float[] getRangeValues();
+    
+    /**
+     * CAUTION: Experimental API, not everything might work as you expect it!
+	 * Colors are set as gradient as according to our use case only.
+     * Calling this method on a dataset ignores its {@link #getColor()} and draws the gradient
+     * colors of {@link #getRangeColors()} instead.
+     *
+     * Always call {@link #setRangeColors} too!
+     *
+     * @param rangeValues 4 range values have to be set the correspond to ranges on the y axis
+     */
+    void setRangeValues(float[] rangeValues);
     
     /**
      * @return cap specifies how the start and end of lines are drawn

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/interfaces/datasets/ILineDataSet.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/interfaces/datasets/ILineDataSet.java
@@ -1,6 +1,7 @@
 package com.github.mikephil.charting.interfaces.datasets;
 
 import android.graphics.DashPathEffect;
+import android.graphics.Paint;
 
 import com.github.mikephil.charting.data.Entry;
 import com.github.mikephil.charting.data.LineDataSet;
@@ -105,4 +106,11 @@ public interface ILineDataSet
     int[] getRangeColors();
 
     float[] getRangeValues();
+    
+    /**
+     * @return cap specifies how the start and end of lines are drawn
+     */
+    Paint.Cap getStrokeCap();
+    
+    void setStrokeCap(Paint.Cap strokeCap);
 }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/interfaces/datasets/ILineDataSet.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/interfaces/datasets/ILineDataSet.java
@@ -105,34 +105,11 @@ public interface ILineDataSet
 
     int[] getRangeColors();
     
-    /**
-	 * CAUTION: Experimental API, not everything might work as you expect it!
-     * Colors are set as gradient as according to our use case only.
-     *
-     * Always call {@link #setRangeValues} too!
-     *
-     * @param rangeColors 3 colors have to be set, which are used for the linear gradient.
-     */
-    void setRangeColors(int[] rangeColors);
-    
     float[] getRangeValues();
-    
-    /**
-     * CAUTION: Experimental API, not everything might work as you expect it!
-	 * Colors are set as gradient as according to our use case only.
-     * Calling this method on a dataset ignores its {@link #getColor()} and draws the gradient
-     * colors of {@link #getRangeColors()} instead.
-     *
-     * Always call {@link #setRangeColors} too!
-     *
-     * @param rangeValues 4 range values have to be set the correspond to ranges on the y axis
-     */
-    void setRangeValues(float[] rangeValues);
     
     /**
      * @return cap specifies how the start and end of lines are drawn
      */
     Paint.Cap getStrokeCap();
     
-    void setStrokeCap(Paint.Cap strokeCap);
 }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
@@ -122,6 +122,7 @@ public class LineChartRenderer
 
         mRenderPaint.setStrokeWidth(dataSet.getLineWidth());
         mRenderPaint.setPathEffect(dataSet.getDashPathEffect());
+        mRenderPaint.setStrokeCap(dataSet.getStrokeCap());
 
         switch (dataSet.getMode()) {
             default:
@@ -140,6 +141,7 @@ public class LineChartRenderer
         }
 
         mRenderPaint.setPathEffect(null);
+        mRenderPaint.setStrokeCap(LineDataSet.DEFAULT_STROKE_CAP);
     }
 
     protected void drawHorizontalBezier(ILineDataSet dataSet) {
@@ -270,7 +272,6 @@ public class LineChartRenderer
         }
 
         mRenderPaint.setStyle(Paint.Style.STROKE);
-        mRenderPaint.setStrokeCap(Paint.Cap.ROUND);
 
         trans.pathValueToPixel(cubicPath);
 

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
@@ -123,6 +123,13 @@ public class LineChartRenderer
         mRenderPaint.setStrokeWidth(dataSet.getLineWidth());
         mRenderPaint.setPathEffect(dataSet.getDashPathEffect());
         mRenderPaint.setStrokeCap(dataSet.getStrokeCap());
+    
+        if (dataSet.getRangeValues() != null && dataSet.getRangeValues().length >= 4) {
+            Shader shader = getGradientShader(dataSet);
+            mRenderPaint.setShader(shader);
+        } else {
+            mRenderPaint.setColor(dataSet.getColor());
+        }
 
         switch (dataSet.getMode()) {
             default:
@@ -142,6 +149,7 @@ public class LineChartRenderer
 
         mRenderPaint.setPathEffect(null);
         mRenderPaint.setStrokeCap(LineDataSet.DEFAULT_STROKE_CAP);
+        mRenderPaint.setShader(null);
     }
 
     protected void drawHorizontalBezier(ILineDataSet dataSet) {
@@ -262,13 +270,6 @@ public class LineChartRenderer
             cubicFillPath.addPath(cubicPath);
 
             drawCubicFill(mBitmapCanvas, dataSet, cubicFillPath, trans, mXBounds);
-        }
-
-        if (dataSet.getRangeValues() != null && dataSet.getRangeValues().length >= 4) {
-            Shader shader = getGradientShader(dataSet);
-            mRenderPaint.setShader(shader);
-        } else {
-            mRenderPaint.setColor(dataSet.getColor());
         }
 
         mRenderPaint.setStyle(Paint.Style.STROKE);

--- a/README-mySugr.md
+++ b/README-mySugr.md
@@ -19,23 +19,21 @@ trying to get the artifacts from a remote repository like jCenter. That
 way you can conveniently do work on the library which is thereafter
 quickly accessible on your app's side.
 
-**On the library side:**
-
-1. Perform your changes
-1. Run the `publishToMavenLocal` task
-
-**On the app side:**
-
-1. On the *first time* Android Studio needs to know the new location of
-   the local artifacts, so clean the dependencies cache (use File /
-   Invalidate Caches / Restart" in Android studio
-1. Once Android Studio knows, you can just use File / Sync with file
-   system each time you used `publishToMavenLocal` (it works in an
-   instant)
-
 ## Publishing
 
-When you've done your work and want to publish your artifacts to the
-public repository you have to push your changes to Bintray. To do that
-just use the `bintrayUpload` task. Make sure you created the version
-you intend to publish on Bintray!
+### Set-up key
+1. Get the Android GPG key from 1Password and copy it to the folder
+2. Fill out the needed properties in local-properties (can also be found in 1Password)
+3. NEVER push anything of this
+4. Now you are good to go
+
+### Publish locally
+1. Perform your changes
+2. Run the `publishToMavenLocal` task
+
+### Publish to the JFrog repository
+To make your changes available for QA or release builds, they need to be published to the
+JFrog repository.
+1. Increase the version in build.gradle
+1. Merge your changes to the mysugr-custom branch
+1. Run the `bintrayUpload` task


### PR DESCRIPTION
Following improvements are introduced:
- The demo app supports now "mySugr charts", which closely resembles our real-life use-cases
- The stroke cap can be set for line data sets, this enables dotted lines instead of only dashed ones
- Setting of range values/gradients can now be done for individual data sets, not for all at once (also added some JavaDoc)
